### PR TITLE
Fix mood entry persistence

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,19 +2,76 @@ import { useEffect, useState } from 'react';
 
 function App() {
   const [apiMessage, setApiMessage] = useState('');
+  const [entries, setEntries] = useState([]);
+  const [emoji, setEmoji] = useState('');
+  const [answers, setAnswers] = useState(Array(5).fill(''));
+
   useEffect(() => {
     fetch('http://localhost:3001/')
-    .then(res => res.text())
-    .then(setApiMessage)
-    .catch(console.error);
+      .then(res => res.text())
+      .then(setApiMessage)
+      .catch(console.error);
+
+    fetchEntries();
   }, []);
 
+  function fetchEntries() {
+    fetch('http://localhost:3001/entries')
+      .then(res => res.json())
+      .then(setEntries)
+      .catch(console.error);
+  }
+
+  function handleAnswerChange(index, value) {
+    setAnswers(prev => {
+      const copy = [...prev];
+      copy[index] = value;
+      return copy;
+    });
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const payload = { id: Date.now().toString(), emoji, answers };
+    await fetch('http://localhost:3001/entries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    setEmoji('');
+    setAnswers(Array(5).fill(''));
+    fetchEntries();
+  }
 
   return (
-    <>
+    <div>
       <h1>{apiMessage}</h1>
-    </>
-  )
+      <form onSubmit={handleSubmit}>
+        <input
+          value={emoji}
+          onChange={e => setEmoji(e.target.value)}
+          placeholder="Emoji"
+        />
+        {answers.map((ans, i) => (
+          <input
+            key={i}
+            value={ans}
+            onChange={e => handleAnswerChange(i, e.target.value)}
+            placeholder={`Answer ${i + 1}`}
+          />
+        ))}
+        <button type="submit">Add Entry</button>
+      </form>
+      <h2>Entries</h2>
+      <ul>
+        {entries.map(entry => (
+          <li key={entry.id}>
+            {entry.emoji} - {entry.answers.join(', ')}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
 
-export default App
+export default App;

--- a/server/index.js
+++ b/server/index.js
@@ -25,8 +25,6 @@ app.post('/entries', async (req, res) => {
   }
 
   await db.read();
-  // Simple “upsert” (replace if same id)
-  db.data.entries = db.data.entries.filter(e => e.id !== id);
   db.data.entries.push({ id, emoji, answers });
   await db.write();
 


### PR DESCRIPTION
## Summary
- keep all mood entries instead of upserting
- fetch and display entries from the API
- add simple form to submit multiple mood entries

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: Exit handler never called)*